### PR TITLE
Add libbsd & libnftables in case host criu is built against these

### DIFF
--- a/test-base/Dockerfile
+++ b/test-base/Dockerfile
@@ -3,5 +3,5 @@ RUN apt-get update && apt-get install -y curl git gcc make
 RUN cd /tmp && git clone https://github.com/fritzw/ld-preload-open && cd ld-preload-open && make all
 
 FROM ubuntu:latest
-RUN apt-get update && apt-get install -y faketime && apt-get clean
+RUN apt-get update && apt-get install -y faketime libbsd0 libnftables1 && apt-get clean
 COPY --from=builder /tmp/ld-preload-open/path-mapping-quiet.so /opt/path-mapping-quiet.so


### PR DESCRIPTION
This should fix running `openjdk/crac` tests with `criu` built on host with `libbsd-devel` installed (and possibly libnftables-devel, too).