### PR TITLE
Add Alpine-based test image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,10 +4,11 @@ on:
     branches:
     - main
 jobs:
-  publish-test-base-image:
+  publish-images:
     runs-on: ubuntu-latest
-    env:
-      IMAGE_NAME: ghcr.io/crac/test-base
+    strategy:
+      matrix:
+        IMAGE_DIR: [ test-base, test-base-musl ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up QEMU
@@ -26,11 +27,10 @@ jobs:
       id: build-and-push
       uses: docker/build-push-action@v4
       with:
-        context: test-base
-        file: test-base/Dockerfile
+        context: ${{ matrix.IMAGE_DIR }}
+        file: ${{ matrix.IMAGE_DIR }}/Dockerfile
         no-cache: true
         platforms: linux/amd64,linux/arm,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
-        tags: |
-          ${{ env.IMAGE_NAME }}
+        tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.IMAGE_DIR }}
 

--- a/test-base-musl/Dockerfile
+++ b/test-base-musl/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest AS builder
+RUN apk add build-base curl git musl-fts-dev
+RUN cd /tmp && git clone https://github.com/fritzw/ld-preload-open
+RUN cd /tmp/ld-preload-open \
+	&& sed -i 's/-Wall//' Makefile \
+	&& sed -i -e 's/struct \([a-zA-Z_0-9]*\)64/struct \1/g' path-mapping.c \
+	&& sed -i -e 's/.*\(define DISABLE_FTW\)/#\1/g' path-mapping.c \
+	&& sed -i '1i#define __OPEN_NEEDS_MODE(oflag) (((oflag) & O_CREAT) != 0 || ((oflag) & O_TMPFILE) == O_TMPFILE)' path-mapping.c \
+	&& make all
+
+FROM alpine:latest
+COPY --from=builder /tmp/ld-preload-open/path-mapping-quiet.so /opt/path-mapping-quiet.so


### PR DESCRIPTION
CRaC tests running with JDK built against `musl` can't run on containers using `glibc`; let's provide an alternative set of images based on Alpine.