### PR TITLE
GHA: Use lowercase repository owner

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,6 +23,10 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Use lowercase repository owner
+      run: |
+        REPO_OWNER=${{ github.repository_owner }}
+        echo "REPO_OWNER=${REPO_OWNER,,}" >>${GITHUB_ENV}
     - name: Build and push Docker image
       id: build-and-push
       uses: docker/build-push-action@v4
@@ -32,5 +36,5 @@ jobs:
         no-cache: true
         platforms: linux/amd64,linux/arm,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
-        tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.IMAGE_DIR }}
+        tags: ghcr.io/${{ env.REPO_OWNER }}/${{ matrix.IMAGE_DIR }}
 


### PR DESCRIPTION
Currently GHA fails with
```
ERROR: invalid tag "ghcr.io/CRaC/test-base": repository name must be lowercase
```