### PR TITLE
Allow to trigger CI manually

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag'
+        description: 'Image tag (empty means infer from branch name or Git tag)'
         type: string
-        default: latest
-        required: true
+        default: ''
+        required: false
       push_image:
         description: 'Push image to registry'
         type: boolean
@@ -20,7 +20,17 @@ jobs:
       matrix:
         IMAGE_DIR: [ test-base, test-base-musl ]
     env:
-      PUSH_IMAGE: ${{ (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'workflow_dispatch' && inputs.push_image) }}
+      IMAGE_TAG: ${{
+          case(
+            github.event_name == 'push' && github.ref == 'refs/heads/main', 'latest',
+            github.event_name == 'workflow_dispatch' && inputs.image_tag != '', inputs.image_tag,
+            github.ref_name
+          )
+        }}
+      PUSH_IMAGE: ${{
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'workflow_dispatch' && inputs.push_image)
+        }}
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -46,4 +56,4 @@ jobs:
         no-cache: true
         platforms: linux/amd64,linux/arm,linux/arm64
         push: ${{ env.PUSH_IMAGE == 'true' }}
-        tags: ghcr.io/${{ env.REPO_OWNER }}/${{ matrix.IMAGE_DIR }}:${{ inputs.image_tag || 'latest' }}
+        tags: ghcr.io/${{ env.REPO_OWNER }}/${{ matrix.IMAGE_DIR }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,25 +1,36 @@
 name: publish
 on:
   push:
-    branches:
-    - main
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag'
+        type: string
+        default: latest
+        required: true
+      push_image:
+        description: 'Push image to registry'
+        type: boolean
+        default: false
+        required: true
 jobs:
   publish-images:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         IMAGE_DIR: [ test-base, test-base-musl ]
+    env:
+      PUSH_IMAGE: ${{ (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'workflow_dispatch' && inputs.push_image) }}
     steps:
-    - uses: actions/checkout@v2
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: 'arm64,arm'
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      if: ${{ env.PUSH_IMAGE == 'true' }}
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -29,13 +40,10 @@ jobs:
         REPO_OWNER=${{ github.repository_owner }}
         echo "REPO_OWNER=${REPO_OWNER,,}" >>${GITHUB_ENV}
     - name: Build and push Docker image
-      id: build-and-push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
-        context: ${{ matrix.IMAGE_DIR }}
-        file: ${{ matrix.IMAGE_DIR }}/Dockerfile
+        context: '{{ defaultContext }}:${{ matrix.IMAGE_DIR }}'
         no-cache: true
         platforms: linux/amd64,linux/arm,linux/arm64
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ghcr.io/${{ env.REPO_OWNER }}/${{ matrix.IMAGE_DIR }}
-
+        push: ${{ env.PUSH_IMAGE == 'true' }}
+        tags: ghcr.io/${{ env.REPO_OWNER }}/${{ matrix.IMAGE_DIR }}:${{ inputs.image_tag || 'latest' }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
 jobs:
   publish-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        platforms: 'arm64,arm'
+        platforms: 'arm64'
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
@@ -54,6 +54,6 @@ jobs:
       with:
         context: '{{ defaultContext }}:${{ matrix.IMAGE_DIR }}'
         no-cache: true
-        platforms: linux/amd64,linux/arm,linux/arm64
+        platforms: linux/amd64,linux/arm64
         push: ${{ env.PUSH_IMAGE == 'true' }}
         tags: ghcr.io/${{ env.REPO_OWNER }}/${{ matrix.IMAGE_DIR }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
This will allow us to trigger publishing [manually](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow) without pushing new commits. For example, when a need to use an updated base image arises.