### PR TITLE
Use stable unshare

### DIFF
--- a/test-base/Dockerfile
+++ b/test-base/Dockerfile
@@ -1,7 +1,11 @@
 FROM ubuntu:latest AS builder
-RUN apt-get update && apt-get install -y curl git gcc make
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git libc6-dev gcc make
 RUN cd /tmp && git clone https://github.com/fritzw/ld-preload-open && cd ld-preload-open && make all
 
 FROM ubuntu:latest
-RUN apt-get update && apt-get install -y faketime libbsd0 libnftables1 && apt-get clean
+RUN apt-get update && apt-get install -y --no-install-recommends faketime libbsd0 libnftables1 && apt-get clean
+# ubuntu:24.04 (latest as of writing this) has a buggy unshare:
+# https://github.com/util-linux/util-linux/issues/2614
+# Once ubuntu:latest uses utils-linux 2.40+ this can be removed.
+COPY --from=ubuntu:22.04 /usr/bin/unshare /usr/bin/unshare
 COPY --from=builder /tmp/ld-preload-open/path-mapping-quiet.so /opt/path-mapping-quiet.so


### PR DESCRIPTION
With `ubuntu:latest` being `ubuntu:24.04` we have crashes in CRaC tests that use `unshare` because it is the version where https://github.com/util-linux/util-linux/issues/2614 is not yet fixed.

This PR makes the glibc-based image use `unshare` from `ubuntu:22.04` with which we did not have problems.

When `ubuntu:latest` becomes `ubuntu:26.04` with a newer `unshare` this will not be needed anymore.

---

I also added `--no-install-recommends` to improve build times and image size, although it does not seems to have helped the builds times.